### PR TITLE
Remove preview changes feature from landing page

### DIFF
--- a/src/components/mla-landing.tsx
+++ b/src/components/mla-landing.tsx
@@ -46,7 +46,6 @@ function Hero() {
             <li className="inline-flex items-center gap-2"><Check className="text-brand size-4"/> Connect with Spotify in seconds</li>
             <li className="inline-flex items-center gap-2"><Check className="text-brand size-4"/> Sync songs between playlists</li>
             <li className="inline-flex items-center gap-2"><Check className="text-brand size-4"/> Transfer playlists between accounts</li>
-            <li className="inline-flex items-center gap-2"><Check className="text-brand size-4"/> Preview changes before applying</li>
           </ul>
         </div>
         <div className="relative">


### PR DESCRIPTION
## Purpose
Remove the "Preview changes before applying" feature listing from the landing page hero section as requested by the user.

## Code changes
- Removed the list item mentioning "Preview changes before applying" from the Hero component's feature list in `src/components/mla-landing.tsx`
- The feature list now contains 3 items instead of 4, focusing on core Spotify integration capabilitiesTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 11`

🔗 [Edit in Builder.io](https://builder.io/app/projects/39b7f6fe4786433c83e9ce072f3f1b93/zen-world)

👀 [Preview Link](https://39b7f6fe4786433c83e9ce072f3f1b93-zen-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>39b7f6fe4786433c83e9ce072f3f1b93</projectId>-->
<!--<branchName>zen-world</branchName>-->